### PR TITLE
adding prettier config to template

### DIFF
--- a/template/typescript/.prettierrc
+++ b/template/typescript/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120
+}

--- a/template/typescript/eslint.config.mjs
+++ b/template/typescript/eslint.config.mjs
@@ -2,12 +2,10 @@ import { defineConfig } from 'eslint/config'
 import globals from 'globals'
 import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
-import stylistic from '@stylistic/eslint-plugin'
 
 export default defineConfig([
   { files: ['**/*.{js,mjs,cjs,ts}'] },
   { files: ['**/*.{js,mjs,cjs,ts}'], languageOptions: { globals: globals.browser } },
   { files: ['**/*.{js,mjs,cjs,ts}'], plugins: { js }, extends: ['js/recommended'] },
   tseslint.configs.recommended,
-  stylistic.configs.recommended,
 ])

--- a/template/typescript/package.json
+++ b/template/typescript/package.json
@@ -20,7 +20,6 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^9.23.0",
-    "@stylistic/eslint-plugin": "^4.2.0",
     "@types/node": "^18.16.0",
     "@types/prompt-sync": "^4.2.3",
     "@typescript-eslint/eslint-plugin": "^8.28.0",


### PR DESCRIPTION
Fixes #2.

The prettier config is different from the main project because the files in the template don't follow the main project's style.